### PR TITLE
Add analysis dashboard hub with dark terminal theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,277 @@
+# Project: Analysis Dashboard Hub
+
+This is an auto-deploying React analysis dashboard site. Every analysis (geopolitical, stock, or other) is created as a `.jsx` component, committed, and pushed to GitHub — which triggers an automatic Vercel deployment.
+
+## Project Structure
+
+```
+/src
+  /dashboards          ← All analysis dashboards go here
+    /geopolitical       ← Geopolitical analysis dashboards
+    /stocks             ← Stock analysis dashboards
+  /components           ← Shared UI components (charts, cards, etc.)
+  App.jsx               ← Main app with routing to all dashboards
+  index.jsx             ← Entry point
+/public
+/CLAUDE.md              ← This file
+```
+
+## Git Workflow
+
+After creating or updating any dashboard:
+1. `git add .`
+2. `git commit -m "feat: [type] analysis - [subject] - [date]"` (e.g., `feat: geopolitical analysis - US-China Trade War - 2026-03-22`)
+3. `git push origin main`
+
+Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`
+
+## Tech Stack
+
+- React 18+ with functional components and hooks
+- Tailwind CSS (core utility classes only)
+- Recharts for all charts and data visualizations
+- lucide-react for icons
+- No localStorage — use React state only
+
+## Design System
+
+### Theme: Dark Financial Terminal
+- **Backgrounds**: Deep navy (`#0a0f1e`), charcoal (`#111827`), slate (`#1e293b`)
+- **Text**: White (`#f8fafc`), muted (`#94a3b8`), dim (`#64748b`)
+- **Accents**: Cyan (`#06b6d4`), emerald (`#10b981`), amber (`#f59e0b`), crimson (`#ef4444`), violet (`#8b5cf6`)
+- **Typography**: Monospace for numbers/data, clean sans-serif for labels and headers
+- **Layout**: Dense, information-rich, CSS grid multi-panel layouts
+- **Interactivity**: Tabs, toggleable sections, hover states, tooltips
+
+### Anti-Patterns (NEVER do these)
+- Generic AI aesthetics (purple gradients on white)
+- Cookie-cutter card layouts
+- Inter/Roboto/Arial fonts
+- Sparse, empty layouts — every pixel should convey information
+
+---
+
+# SKILL: Geopolitical Decision Analyzer & Predictor
+
+## When to Use
+Trigger when the user asks about: geopolitical analysis, international relations, foreign policy predictions, trade war outcomes, military strategy, diplomatic scenarios, sanctions impact, alliance dynamics, regional conflict assessment, or any question about how countries might act and what consequences could follow.
+
+## Core Analytical Framework
+
+Every geopolitical analysis follows this pipeline — don't skip steps:
+
+### Step 1: Situation Assessment
+- **Actors**: Key state and non-state actors, stated and unstated interests
+- **Context**: Historical precedents, treaties, alliances, economic relationships
+- **Triggers**: Recent events or emerging trends prompting the analysis
+- **Power Dynamics**: Relative military, economic, technological, and soft power
+- **Domestic Politics**: Election cycles, public opinion, factions, leadership stability
+
+### Step 2: Decision Tree Mapping
+- Realistic options available to each major actor
+- Constraints (legal, economic, military, domestic political)
+- Sequences: if Actor A does X, what opens/closes for Actor B?
+
+### Step 3: Multi-Scenario Construction (3-5 scenarios)
+Each scenario must have:
+- **Name**: Evocative label (e.g., "Cold Detente", "Economic Iron Curtain")
+- **Description**: Paragraph narrative of how events unfold
+- **Probability**: Percentage likelihood (all must sum to ~100%)
+- **Time horizons**: Short-term (0-6mo), Medium (6-24mo), Long (2-10yr)
+- **Impact ratings**: Scored 1-10 across dimensions
+
+### Step 4: Feasibility & Sustainability Assessment
+For every major action in each scenario, assess:
+
+**Military Feasibility**: Force projection, sustainability, terrain, track record
+**Economic Capacity**: Reserves, debt tolerance, sanctions resilience, GDP impact
+**Political Will**: Public support, elite consensus, electoral vulnerability, casualty tolerance
+**Alliance Viability**: Who's actually committed, coalition fracture points
+
+**Sustainability Ratings**:
+- Fully Sustainable (can maintain indefinitely)
+- Sustainable Short-Term (6-18 months before strain)
+- Barely Feasible (severe strain immediately)
+- Not Feasible (unrealistic despite theoretical capability)
+
+### Step 5: Impact Assessment (1-10 scale)
+| Dimension | What It Measures |
+|---|---|
+| Military/Security | Armed conflict risk, arms races, security posture |
+| Economic/Trade | GDP impact, trade disruption, sanctions, market volatility |
+| Diplomatic | Alliance shifts, institutional changes, treaty implications |
+| Humanitarian | Civilian impact, refugees, human rights |
+| Regional Stability | Spillover effects, neighboring responses |
+| Global Systemic | International norms, precedents, world order |
+
+### Step 6: Key Indicators & Signposts
+For each scenario, identify 3-5 observable, monitorable indicators:
+- Diplomatic appointments/recalls
+- Military deployment patterns
+- Trade data shifts
+- Public statements with specific language
+- Votes at international bodies
+- Economic indicators crossing thresholds
+
+### Step 7: Expert & Institutional Opinion Analysis
+Search for and synthesize expert opinions from:
+- **Think tanks**: Brookings, RAND, CFR, IISS, Chatham House, Carnegie, CSIS, SIPRI, RUSI, Lowy, ECFR
+- **Government-adjacent**: Former diplomats, ex-intel officials, retired military
+- **Academics**: Regional/domain specialists
+- **Local/regional voices**: Analysts from affected countries
+
+Structure as:
+1. **Consensus View** — mainstream position
+2. **Dissenting Views** — credible contrarians and reasoning
+3. **Regional vs. Western Gap** — perspective differences
+4. **Expert Confidence Level** — high confidence or heavy hedging?
+5. **Track Record** — did they get previous calls right?
+
+## Dashboard Output
+
+Create a React `.jsx` file in `/src/dashboards/geopolitical/` with these sections:
+
+1. **Situation Overview Panel**: Actors, context, timeline
+2. **Scenario Cards**: Name, probability gauge, description
+3. **Feasibility Reality Check Panel**: Radar charts of 4 feasibility dimensions, sustainability badges, dealbreaker callouts, estimated costs
+4. **Impact Heatmap**: Matrix of impact scores, color-coded green→red
+5. **Decision Tree Visualization**: Flowchart of decisions leading to scenarios
+6. **Key Indicators Tracker**: Checklist of signposts per scenario
+7. **Expert Opinion Panel**: Consensus, dissenting views, regional vs Western gap
+8. **Timeline View**: Projected events per scenario across time horizons
+
+## Data Structure
+
+```javascript
+const analysisData = {
+  title: "Analysis Title",
+  date: "YYYY-MM-DD",
+  overallConfidence: "Medium-High",
+  situation: {
+    actors: [...],
+    context: "...",
+    triggers: ["..."],
+    powerDynamics: {...}
+  },
+  scenarios: [
+    {
+      id: 1,
+      name: "Scenario Name",
+      probability: 35,
+      description: "...",
+      narrative: "...",
+      impacts: { military: 7, economic: 8, diplomatic: 5, humanitarian: 6, regional: 7, global: 6 },
+      timeHorizons: { shortTerm: "...", mediumTerm: "...", longTerm: "..." },
+      indicators: [{ signal: "...", status: "not_observed" | "emerging" | "observed" }],
+      feasibility: [
+        {
+          action: "Description of the action",
+          actor: "Country/entity",
+          militaryFeasibility: { score: 3, detail: "..." },
+          economicCapacity: { score: 4, detail: "..." },
+          politicalWill: { score: 2, detail: "..." },
+          allianceSupport: { score: 5, detail: "..." },
+          overallSustainability: "not_feasible",
+          dealbreaker: "The single biggest reason this could fail",
+          estimatedCost: "$X billion/trillion over Y years"
+        }
+      ]
+    }
+  ],
+  decisionPoints: [{ actor: "...", decision: "...", leadsTo: [scenarioIds] }],
+  expertOpinions: {
+    consensus: { summary: "...", supporters: ["RAND", "Brookings"] },
+    dissenting: [{ expert: "...", affiliation: "...", position: "...", reasoning: "...", credibilityNote: "..." }],
+    regionalVsWestern: { westernView: "...", regionalView: "...", gapAnalysis: "..." },
+    overallExpertConfidence: "High"
+  }
+};
+```
+
+## Written Report
+
+Also generate a Word document (.docx) report with this structure:
+1. Executive Summary
+2. Situation Assessment
+3. Scenario Analysis
+4. Feasibility & Sustainability Deep Dive
+5. Key Indicators & Signposts
+6. Expert & Institutional Analysis
+7. Risk Matrix
+8. Recommendations & Watchpoints
+9. Methodology Note
+
+## Analytical Principles
+
+- **Epistemic humility**: Acknowledge uncertainty, be explicit about assumptions
+- **Avoid single-outcome thinking**: Map the full range of possibilities
+- **Second-order effects**: Think in systems — A affects B, C, D, E...
+- **Historical analogies**: Draw on precedents but note differences
+- **Domestic politics matters enormously**: Analyze the humans, not just the states
+- **Economic interdependence is double-edged**: Can prevent or intensify conflict
+
+## Web Search Strategy
+1. Latest developments on the specific situation
+2. Recent policy statements from key actors
+3. Expert/think tank analysis (RAND, Brookings, CFR, IISS, etc.)
+4. Dissenting/contrarian expert views
+5. Analysts from the affected region
+6. Relevant economic/military data
+7. Historical precedents
+
+---
+
+# SKILL: Stock Analyzer
+
+## When to Use
+Trigger for: stock analysis, financial analysis, investment research, portfolio review, market analysis, stock comparison, equity research, ticker symbols (AAPL, TSLA, etc.), "should I invest in...", "how is X stock doing", P/E ratios, market sentiment.
+
+## Workflow
+
+### Step 1: Gather Stock Information
+Run multiple web searches:
+- **Price & Technical**: `[TICKER] stock price today`, `[TICKER] technical analysis`
+- **Fundamentals**: `[TICKER] financials earnings revenue P/E ratio`, `[TICKER] balance sheet market cap`
+- **News & Sentiment**: `[TICKER] stock news latest`, `[TICKER] analyst rating sentiment`
+- **Event Impact**: `[TICKER] geopolitical risk exposure`, `[TICKER] impact war sanctions tariffs`, `current geopolitical events affecting [SECTOR] stocks`
+- **Comparison** (if multiple): Each ticker individually, then `[TICKER1] vs [TICKER2]`
+
+### Step 2: Build the Dashboard
+Create a React `.jsx` file in `/src/dashboards/stocks/` with these sections:
+
+1. **Header / Overview**: Stock name, ticker, price, daily change, key stats (Market Cap, P/E, EPS, Dividend Yield, 52-week range)
+2. **Technical Analysis Panel**: Price chart (Recharts), support/resistance, trend direction, moving averages, buy/sell/hold indicator
+3. **Fundamental Analysis Panel**: Financial metrics grid, revenue/earnings trend, valuation assessment, competitive positioning
+4. **News & Sentiment Panel**: 3-5 headlines with dates, sentiment gauge, analyst consensus
+5. **Event Impact Analysis Panel**: Current events impact matrix (event, level, direction, rationale), historical parallels, risk/opportunity factors
+6. **Comparison Panel** (multi-stock): Side-by-side metrics, radar chart, relative performance
+
+### Technical Requirements
+- Single `.jsx` file, default export
+- Tailwind core utilities only
+- Recharts for charts
+- lucide-react for icons
+- All data in component state — no localStorage
+- **Always include disclaimer**: "This analysis is for informational purposes only and does not constitute financial advice. Always consult a qualified financial advisor before making investment decisions."
+
+### Important Rules
+- **Never give direct buy/sell recommendations** — present data objectively
+- **Be honest about data limitations** — note when figures are approximate
+- **Cite sources** in commit messages or comments
+- Frame as "the data suggests..." not "you should buy/sell..."
+
+---
+
+# General Dashboard Guidelines
+
+## After Every Analysis
+
+1. Save the `.jsx` file to the appropriate `/src/dashboards/` subdirectory
+2. Update `App.jsx` to include routing to the new dashboard
+3. Commit with descriptive message
+4. Push to GitHub (triggers Vercel auto-deploy)
+5. Confirm the deployment URL to the user
+
+## File Naming Convention
+- Geopolitical: `[country1]-[country2]-[topic]-[YYYY-MM-DD].jsx` (e.g., `us-china-trade-war-2026-03-22.jsx`)
+- Stocks: `[ticker]-analysis-[YYYY-MM-DD].jsx` (e.g., `tsla-analysis-2026-03-22.jsx`)

--- a/index.html
+++ b/index.html
@@ -1,10 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>vite-scaffold</title>
+    <title>Analysis Dashboards</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-scaffold",
+  "name": "analysis-dashboards",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-scaffold",
+      "name": "analysis-dashboards",
       "version": "0.0.0",
       "dependencies": {
         "lucide-react": "^0.577.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-scaffold",
+  "name": "analysis-dashboards",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,62 +1,100 @@
+import { useState } from 'react'
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
-import { Globe, TrendingUp } from 'lucide-react'
+import { BarChart3, Globe2, TrendingUp, Clock } from 'lucide-react'
 
-function DashboardIndex() {
-  const dashboards = [
-    {
-      title: 'Geopolitical Analysis',
-      description: 'Analyze and predict geopolitical decisions and their outcomes',
-      path: '/dashboards/geopolitical',
-      icon: <Globe className="w-8 h-8" />,
-    },
-    {
-      title: 'Stock Analysis',
-      description: 'Financial insights and interactive stock dashboards',
-      path: '/dashboards/stocks',
-      icon: <TrendingUp className="w-8 h-8" />,
-    },
-  ]
+// Import dashboards here as they are created
+// import UsChina from './dashboards/geopolitical/us-china-trade-war-2026-03-22'
+// import TslaAnalysis from './dashboards/stocks/tsla-analysis-2026-03-22'
 
+const dashboards = [
+  // Add entries here as dashboards are created:
+  // { path: '/geo/us-china-trade', component: UsChina, title: 'US-China Trade War', type: 'geopolitical', date: '2026-03-22' },
+  // { path: '/stock/tsla', component: TslaAnalysis, title: 'Tesla Analysis', type: 'stock', date: '2026-03-22' },
+]
+
+function Home() {
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100">
-      <header className="border-b border-gray-800 px-6 py-4">
-        <h1 className="text-2xl font-bold">AI Analysis Dashboards</h1>
-      </header>
-      <main className="max-w-4xl mx-auto p-8">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {dashboards.map((d) => (
-            <Link
-              key={d.path}
-              to={d.path}
-              className="block p-6 rounded-xl border border-gray-800 bg-gray-900 hover:border-gray-600 transition-colors"
-            >
-              <div className="mb-3 text-blue-400">{d.icon}</div>
-              <h2 className="text-lg font-semibold mb-1">{d.title}</h2>
-              <p className="text-sm text-gray-400">{d.description}</p>
-            </Link>
-          ))}
+    <div style={{ minHeight: '100vh', backgroundColor: '#0a0f1e', padding: '2rem' }}>
+      <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ marginBottom: '3rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.5rem' }}>
+            <BarChart3 size={32} color="#06b6d4" />
+            <h1 style={{ fontSize: '2rem', fontWeight: 700, color: '#f8fafc', margin: 0 }}>
+              Analysis Dashboard Hub
+            </h1>
+          </div>
+          <p style={{ color: '#94a3b8', fontSize: '1.1rem', margin: 0 }}>
+            Geopolitical & Financial Intelligence Dashboards
+          </p>
         </div>
-      </main>
-    </div>
-  )
-}
 
-function GeopoliticalPlaceholder() {
-  return (
-    <div className="min-h-screen bg-gray-950 text-gray-100 p-8">
-      <Link to="/" className="text-blue-400 hover:underline text-sm">&larr; Back to dashboards</Link>
-      <h1 className="text-2xl font-bold mt-4">Geopolitical Analysis</h1>
-      <p className="text-gray-400 mt-2">Dashboard content will go here.</p>
-    </div>
-  )
-}
-
-function StocksPlaceholder() {
-  return (
-    <div className="min-h-screen bg-gray-950 text-gray-100 p-8">
-      <Link to="/" className="text-blue-400 hover:underline text-sm">&larr; Back to dashboards</Link>
-      <h1 className="text-2xl font-bold mt-4">Stock Analysis</h1>
-      <p className="text-gray-400 mt-2">Dashboard content will go here.</p>
+        {/* Dashboard Grid */}
+        {dashboards.length === 0 ? (
+          <div style={{
+            border: '1px dashed #334155',
+            borderRadius: '12px',
+            padding: '3rem',
+            textAlign: 'center',
+            color: '#64748b'
+          }}>
+            <Globe2 size={48} style={{ margin: '0 auto 1rem', opacity: 0.5 }} />
+            <h2 style={{ color: '#94a3b8', marginBottom: '0.5rem' }}>No Analyses Yet</h2>
+            <p>Ask Claude Code to create your first analysis dashboard.</p>
+            <p style={{ fontSize: '0.875rem', marginTop: '1rem' }}>
+              Try: "Analyze US-China trade relations" or "Analyze Tesla stock"
+            </p>
+          </div>
+        ) : (
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(350px, 1fr))',
+            gap: '1.5rem'
+          }}>
+            {dashboards.map((d) => (
+              <Link
+                key={d.path}
+                to={d.path}
+                style={{
+                  background: '#111827',
+                  border: '1px solid #1e293b',
+                  borderRadius: '12px',
+                  padding: '1.5rem',
+                  textDecoration: 'none',
+                  transition: 'border-color 0.2s',
+                  cursor: 'pointer',
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.borderColor = '#06b6d4'}
+                onMouseLeave={(e) => e.currentTarget.style.borderColor = '#1e293b'}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.75rem' }}>
+                  {d.type === 'geopolitical' ? (
+                    <Globe2 size={18} color="#f59e0b" />
+                  ) : (
+                    <TrendingUp size={18} color="#10b981" />
+                  )}
+                  <span style={{
+                    fontSize: '0.75rem',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    color: d.type === 'geopolitical' ? '#f59e0b' : '#10b981',
+                    fontWeight: 600,
+                  }}>
+                    {d.type}
+                  </span>
+                </div>
+                <h3 style={{ color: '#f8fafc', fontSize: '1.25rem', fontWeight: 600, margin: '0 0 0.5rem' }}>
+                  {d.title}
+                </h3>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', color: '#64748b', fontSize: '0.875rem' }}>
+                  <Clock size={14} />
+                  <span>{d.date}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }
@@ -65,9 +103,10 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<DashboardIndex />} />
-        <Route path="/dashboards/geopolitical/*" element={<GeopoliticalPlaceholder />} />
-        <Route path="/dashboards/stocks/*" element={<StocksPlaceholder />} />
+        <Route path="/" element={<Home />} />
+        {dashboards.map((d) => (
+          <Route key={d.path} path={d.path} element={<d.component />} />
+        ))}
       </Routes>
     </BrowserRouter>
   )

--- a/src/dashboards/geopolitical/README.md
+++ b/src/dashboards/geopolitical/README.md
@@ -1,0 +1,2 @@
+# Geopolitical Analysis Dashboards
+Place .jsx dashboard files here.

--- a/src/dashboards/stocks/README.md
+++ b/src/dashboards/stocks/README.md
@@ -1,0 +1,2 @@
+# Stock Analysis Dashboards
+Place .jsx dashboard files here.

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,8 @@
 @import "tailwindcss";
+
+body {
+  margin: 0;
+  background-color: #0a0f1e;
+  color: #f8fafc;
+  font-family: system-ui, -apple-system, sans-serif;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
 import './index.css'
-import App from './App.jsx'
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
     <App />
-  </StrictMode>,
+  </React.StrictMode>,
 )

--- a/watcher.js
+++ b/watcher.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+
+/**
+ * Analysis Watcher — Polls GitHub Issues and triggers Claude Code
+ *
+ * HOW IT WORKS:
+ * 1. Runs in the background on your desktop
+ * 2. Checks your GitHub repo for new Issues with "analyze:" prefix every 2 minutes
+ * 3. When it finds one, it launches Claude Code with the analysis request
+ * 4. Claude Code creates the dashboard, commits, and pushes
+ * 5. Vercel auto-deploys — you see results on your phone
+ *
+ * SETUP:
+ * 1. Make sure `gh` (GitHub CLI) is installed and authenticated: `gh auth login`
+ * 2. Make sure `claude` (Claude Code) is installed and authenticated
+ * 3. Edit the CONFIG section below with your repo details
+ * 4. Run: `node watcher.js`
+ *
+ * FROM YOUR PHONE:
+ * - Open GitHub app or browser
+ * - Go to your repo → Issues → New Issue
+ * - Title: "analyze: US war in Iran" (or any analysis request)
+ * - That's it! The watcher picks it up automatically.
+ */
+
+const { execSync, spawn } = require('child_process');
+const path = require('path');
+
+// ============================================
+// CONFIG — EDIT THESE VALUES
+// ============================================
+const CONFIG = {
+  // Your GitHub username and repo name
+  owner: 'YOUR_GITHUB_USERNAME',
+  repo: 'analysis-dashboards',
+
+  // How often to check for new issues (in milliseconds)
+  // 120000 = 2 minutes
+  pollInterval: 120000,
+
+  // The path to your local project folder
+  projectPath: path.join(process.env.HOME || process.env.USERPROFILE, 'Desktop', 'analysis-dashboards'),
+
+  // Label to add to issues after processing
+  doneLabel: 'completed',
+
+  // Label to add to issues that are currently being processed
+  processingLabel: 'in-progress',
+};
+
+// ============================================
+// WATCHER LOGIC — NO NEED TO EDIT BELOW
+// ============================================
+
+const log = (msg) => {
+  const timestamp = new Date().toLocaleTimeString();
+  console.log(`[${timestamp}] ${msg}`);
+};
+
+const logError = (msg) => {
+  const timestamp = new Date().toLocaleTimeString();
+  console.error(`[${timestamp}] ${msg}`);
+};
+
+/**
+ * Fetch open issues with "analyze:" in the title using GitHub CLI
+ */
+function getAnalysisIssues() {
+  try {
+    const result = execSync(
+      `gh issue list --repo ${CONFIG.owner}/${CONFIG.repo} --state open --json number,title,body --limit 10`,
+      { encoding: 'utf-8', timeout: 30000 }
+    );
+
+    const issues = JSON.parse(result);
+
+    // Filter for issues that start with "analyze:" (case-insensitive)
+    return issues.filter(issue =>
+      issue.title.toLowerCase().startsWith('analyze:') &&
+      !issue.title.toLowerCase().includes('[processing]') &&
+      !issue.title.toLowerCase().includes('[done]')
+    );
+  } catch (err) {
+    logError(`Failed to fetch issues: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Add a label and comment to an issue
+ */
+function updateIssue(issueNumber, status, comment) {
+  try {
+    // Add comment
+    execSync(
+      `gh issue comment ${issueNumber} --repo ${CONFIG.owner}/${CONFIG.repo} --body "${comment}"`,
+      { encoding: 'utf-8', timeout: 15000 }
+    );
+
+    // Update title to show status
+    if (status === 'processing') {
+      execSync(
+        `gh issue edit ${issueNumber} --repo ${CONFIG.owner}/${CONFIG.repo} --add-label "${CONFIG.processingLabel}"`,
+        { encoding: 'utf-8', timeout: 15000 }
+      );
+    } else if (status === 'done') {
+      execSync(
+        `gh issue edit ${issueNumber} --repo ${CONFIG.owner}/${CONFIG.repo} --add-label "${CONFIG.doneLabel}" --remove-label "${CONFIG.processingLabel}"`,
+        { encoding: 'utf-8', timeout: 15000 }
+      );
+      // Close the issue
+      execSync(
+        `gh issue close ${issueNumber} --repo ${CONFIG.owner}/${CONFIG.repo}`,
+        { encoding: 'utf-8', timeout: 15000 }
+      );
+    }
+  } catch (err) {
+    logError(`Failed to update issue #${issueNumber}: ${err.message}`);
+  }
+}
+
+/**
+ * Run Claude Code with the analysis prompt
+ */
+function runClaudeCode(analysisRequest, issueNumber) {
+  return new Promise((resolve, reject) => {
+    const fullPrompt = `${analysisRequest}. After creating the dashboard JSX file, update App.jsx to include routing for it, then commit all changes with a descriptive message and push to origin main.`;
+
+    log(`Launching Claude Code: "${analysisRequest}"`);
+
+    const claude = spawn('claude', ['-p', fullPrompt], {
+      cwd: CONFIG.projectPath,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: true,
+      timeout: 600000, // 10 minute timeout
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    claude.stdout.on('data', (data) => {
+      const text = data.toString();
+      stdout += text;
+      process.stdout.write(text); // Show Claude's output in real-time
+    });
+
+    claude.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    claude.on('close', (code) => {
+      if (code === 0) {
+        log(`Claude Code finished successfully for issue #${issueNumber}`);
+        resolve(stdout);
+      } else {
+        logError(`Claude Code exited with code ${code}`);
+        reject(new Error(`Claude Code failed: ${stderr}`));
+      }
+    });
+
+    claude.on('error', (err) => {
+      logError(`Failed to start Claude Code: ${err.message}`);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Process a single issue
+ */
+async function processIssue(issue) {
+  const { number, title, body } = issue;
+
+  // Extract the analysis request (everything after "analyze:")
+  const analysisRequest = title.replace(/^analyze:\s*/i, '').trim();
+  const additionalContext = body ? `\n\nAdditional context: ${body}` : '';
+  const fullRequest = `Analyze ${analysisRequest}${additionalContext}`;
+
+  log(`Processing issue #${number}: "${analysisRequest}"`);
+
+  // Mark as processing
+  updateIssue(number, 'processing', 'Analysis started. Claude Code is working on this. You will be notified when the dashboard is live.');
+
+  try {
+    await runClaudeCode(fullRequest, number);
+
+    // Get the Vercel URL (you can customize this)
+    const siteUrl = `https://${CONFIG.repo}.vercel.app`;
+
+    updateIssue(
+      number,
+      'done',
+      `Analysis complete!\n\nDashboard deployed: ${siteUrl}\n\nThe analysis has been pushed to the repository and should be live on Vercel within ~30 seconds.`
+    );
+  } catch (err) {
+    updateIssue(
+      number,
+      'done',
+      `Analysis failed.\n\nError: ${err.message}\n\nPlease check the desktop logs or try again.`
+    );
+  }
+}
+
+/**
+ * Main polling loop
+ */
+async function poll() {
+  log('Checking for new analysis requests...');
+
+  const issues = getAnalysisIssues();
+
+  if (issues.length === 0) {
+    log('No new requests found.');
+    return;
+  }
+
+  log(`Found ${issues.length} new request(s)!`);
+
+  // Process one at a time (to avoid overwhelming Claude Code)
+  for (const issue of issues) {
+    await processIssue(issue);
+  }
+}
+
+/**
+ * Ensure required tools are available
+ */
+function checkPrerequisites() {
+  log('Checking prerequisites...');
+
+  try {
+    execSync('gh --version', { encoding: 'utf-8', stdio: 'pipe' });
+    log('  GitHub CLI (gh) found');
+  } catch {
+    logError('GitHub CLI (gh) not found. Install: https://cli.github.com');
+    process.exit(1);
+  }
+
+  try {
+    execSync('claude --version', { encoding: 'utf-8', stdio: 'pipe' });
+    log('  Claude Code found');
+  } catch {
+    logError('Claude Code not found. Install: npm install -g @anthropic-ai/claude-code');
+    process.exit(1);
+  }
+
+  try {
+    execSync('gh auth status', { encoding: 'utf-8', stdio: 'pipe' });
+    log('  GitHub CLI authenticated');
+  } catch {
+    logError('GitHub CLI not authenticated. Run: gh auth login');
+    process.exit(1);
+  }
+
+  // Check if project directory exists
+  try {
+    const fs = require('fs');
+    if (!fs.existsSync(CONFIG.projectPath)) {
+      logError(`Project directory not found: ${CONFIG.projectPath}`);
+      logError('Please update CONFIG.projectPath in this script.');
+      process.exit(1);
+    }
+    log(`  Project directory found: ${CONFIG.projectPath}`);
+  } catch {
+    logError('Could not verify project directory');
+    process.exit(1);
+  }
+
+  // Ensure labels exist
+  try {
+    execSync(
+      `gh label create "${CONFIG.doneLabel}" --repo ${CONFIG.owner}/${CONFIG.repo} --color 0E8A16 --description "Analysis completed" --force`,
+      { encoding: 'utf-8', stdio: 'pipe' }
+    );
+    execSync(
+      `gh label create "${CONFIG.processingLabel}" --repo ${CONFIG.owner}/${CONFIG.repo} --color FBCA04 --description "Analysis in progress" --force`,
+      { encoding: 'utf-8', stdio: 'pipe' }
+    );
+    log('  GitHub labels configured');
+  } catch {
+    log('  Could not create labels (may already exist)');
+  }
+}
+
+// ============================================
+// START
+// ============================================
+
+console.log('');
+console.log('========================================');
+console.log('  Analysis Dashboard Watcher v1.0');
+console.log('');
+console.log('  Watching for GitHub Issues...');
+console.log('  Create an issue with title:');
+console.log('  "analyze: [your request]"');
+console.log('');
+console.log('  Press Ctrl+C to stop');
+console.log('========================================');
+console.log('');
+
+checkPrerequisites();
+
+log(`Polling every ${CONFIG.pollInterval / 1000} seconds`);
+log('Watcher started! Waiting for analysis requests...');
+console.log('');
+
+// Run immediately, then on interval
+poll();
+setInterval(poll, CONFIG.pollInterval);


### PR DESCRIPTION
## Summary
- Replace Vite scaffold with dark financial terminal themed dashboard hub (`#0a0f1e` backgrounds, cyan/emerald accents)
- Add `CLAUDE.md` with full project guide, design system, and geopolitical/stock analyzer skill specs
- Add `watcher.js` for automated GitHub Issues-to-Claude Code analysis pipeline
- Add dashboard directory READMEs and data-driven routing in App.jsx

## Test plan
- [ ] Run `npm install && npm run build` — verify clean build
- [ ] Run `npm run dev` — verify dark-themed home page renders
- [ ] Verify `CLAUDE.md` is present at project root
- [ ] Verify `src/dashboards/geopolitical/` and `src/dashboards/stocks/` directories exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)